### PR TITLE
Ajout de la possibilité de configurer Matterbridge

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -1,0 +1,11 @@
+version = "1.0"
+[main]
+services = ["__APP__"]
+
+    [main.config]
+        [main.config.file]
+        ask.fr = "Fichier de configuration"
+        ask.en = "Configuration file"
+        type = "file"
+        bind = "__INSTALL_DIR__/matterbridge.toml"
+

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,3 +1,3 @@
 ## Configuration
 
-How to configure this app: a plain file with SSH `/opt/yunohost/matterbridge/matterbridge.toml`. You can follow this [doc](https://github.com/42wim/matterbridge/wiki/How-to-create-your-config) on how to create your config.
+How to configure this app: You can follow this [doc](https://github.com/42wim/matterbridge/wiki/How-to-create-your-config) on how to create your config.

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -1,3 +1,3 @@
 ## Configuration
 
-Comment configurer cette application : un fichier brut en SSH `/opt/yunohost/matterbridge/matterbridge.toml`. Vous pouvez suivre cette [documentation](https://github.com/42wim/matterbridge/wiki/How-to-create-your-config) sur la façon de créer votre config. 
+Comment configurer cette application : Vous pouvez suivre cette [documentation](https://github.com/42wim/matterbridge/wiki/How-to-create-your-config) sur la façon de créer votre config. 

--- a/scripts/config
+++ b/scripts/config
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#!/bin/bash
+# In simple cases, you don't need a config script.
+
+# With a simple config_panel.toml, you can write in the app settings, in the
+# upstream config file or replace complete files (logo ...) and restart services.
+
+# The config scripts allows you to go further, to handle specific cases
+# (validation of several interdependent fields, specific getter/setter for a value,
+# display dynamic informations or choices, pre-loading of config type .cube... ).
+
+#=================================================
+# IMPORT GENERIC HELPERS
+#=================================================
+
+source /usr/share/yunohost/helpers
+
+ynh_abort_if_errors
+
+#=================================================
+ynh_app_config_run "$1"


### PR DESCRIPTION
A travers l'interface de configuration

## Problem

- *I wanted to add the possibilty to modify the configuration file with the configu panel without login to ssl*

## Solution

- *I added a basic configu script and config panel to ease th acces of the __install_dir__/matterbrige.toml*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
